### PR TITLE
Add the possibility to pass a custom fetch to an instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ const loader = new VASTLoader(tagUrl)
 
 // Load the tag chain and await the resulting Promise
 loader.load()
-  .then((chain) => {
+  .then(chain => {
     console.info('Loaded VAST tags:', chain)
   })
-  .catch((err) => {
+  .catch(err => {
     console.error('Error loading tag:', err)
   })
 ```
@@ -53,7 +53,7 @@ import { VASTLoader, VASTLoaderError } from 'iab-vast-loader'
 const loader = new VASTLoader(tagUrl)
 
 loader.load()
-  .catch((err) => {
+  .catch(err => {
     if (err instanceof VASTLoaderError) {
       console.error('VAST error: ' + err.code + ' ' + err.message)
     } else {
@@ -99,7 +99,7 @@ request URL and returning one of the accepted values. For example:
 
 ```js
 const loader = new VASTLoader(wrapperUrl, {
-  credentials (uri) {
+  credentials: uri => {
     if (uri.indexOf('.doubleclick.net/') >= 0) {
       return 'include'
     } else {
@@ -108,6 +108,14 @@ const loader = new VASTLoader(wrapperUrl, {
   }
 })
 ```
+
+### `fetch`
+
+Sets the implementation of
+[`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API), used to
+make HTTP requests. In Node.js, this defaults to
+[node-fetch](https://www.npmjs.com/package/node-fetch). In the browser,
+[unfetch](https://www.npmjs.com/package/unfetch) is used.
 
 ## Events
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -24,8 +24,9 @@ class VASTLoader extends EventEmitter {
     } else {
       this._root = this
       this._options = Object.assign({}, DEFAULT_OPTIONS, options)
-      this._fetch = this._options.fetch
       this._depth = 1
+      this._fetch =
+        this._options.fetch != null ? this._options.fetch : VASTLoader.fetch
     }
   }
 
@@ -34,12 +35,6 @@ class VASTLoader extends EventEmitter {
       this._emit('error', { error })
       throw error
     })
-  }
-
-  fetch (...args) {
-    return this._root._fetch != null
-      ? this._root._fetch(...args)
-      : VASTLoader.fetch(...args)
   }
 
   _load (uri) {
@@ -121,7 +116,8 @@ class VASTLoader extends EventEmitter {
   }
 
   _tryFetch (uri, credentials) {
-    return this.fetch(uri, { credentials })
+    return this._root
+      ._fetch(uri, { credentials })
       .then(response => {
         if (!response.ok) {
           const httpError = new HTTPError(response.status, response.statusText)

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -24,6 +24,7 @@ class VASTLoader extends EventEmitter {
     } else {
       this._root = this
       this._options = Object.assign({}, DEFAULT_OPTIONS, options)
+      this._fetch = this._options.fetch
       this._depth = 1
     }
   }
@@ -33,6 +34,12 @@ class VASTLoader extends EventEmitter {
       this._emit('error', { error })
       throw error
     })
+  }
+
+  fetch (...args) {
+    return this._root._fetch != null
+      ? this._root._fetch(...args)
+      : VASTLoader.fetch(...args)
   }
 
   _load (uri) {
@@ -114,7 +121,7 @@ class VASTLoader extends EventEmitter {
   }
 
   _tryFetch (uri, credentials) {
-    return VASTLoader.fetch(uri, { credentials })
+    return this.fetch(uri, { credentials })
       .then(response => {
         if (!response.ok) {
           const httpError = new HTTPError(response.status, response.statusText)

--- a/test/unit/node.js
+++ b/test/unit/node.js
@@ -9,7 +9,7 @@ const { atob } = require('../../lib/node/atob')
 VASTLoader.atob = atob
 
 const EMPTY_VAST_2 = `<?xml version="1.0" encoding="UTF-8"?><VAST version="2.0"/>`
-const EMPTY_VAST_3 = `<?xml version="1.0" encoding="UTF-8"?><VAST version="2.0"/>`
+const EMPTY_VAST_3 = `<?xml version="1.0" encoding="UTF-8"?><VAST version="3.0"/>`
 
 const mockFetch = body =>
   new Promise((resolve, reject) => resolve({ ok: true, text: () => body }))
@@ -355,10 +355,10 @@ describe('VASTLoader', function () {
         fetch: (...args) => mockFetch(EMPTY_VAST_3)
       })
       loader1.on('didFetch', ({ body }) => {
-        expect(body).to.equal(EMPTY_VAST_3)
-      })
-      loader1.on('didFetch', ({ body }) => {
         expect(body).to.equal(EMPTY_VAST_2)
+      })
+      loader2.on('didFetch', ({ body }) => {
+        expect(body).to.equal(EMPTY_VAST_3)
       })
       await Promise.all([loader1.load(), loader2.load()])
     })

--- a/test/unit/node.js
+++ b/test/unit/node.js
@@ -11,8 +11,11 @@ VASTLoader.atob = atob
 const EMPTY_VAST_2 = `<?xml version="1.0" encoding="UTF-8"?><VAST version="2.0"/>`
 const EMPTY_VAST_3 = `<?xml version="1.0" encoding="UTF-8"?><VAST version="3.0"/>`
 
-const mockFetch = body =>
-  new Promise((resolve, reject) => resolve({ ok: true, text: () => body }))
+const mockFetch = body => () =>
+  Promise.resolve({
+    ok: true,
+    text: () => Promise.resolve(body)
+  })
 
 const expectLoaderError = (error, code, message, cause) => {
   expect(error).to.be.an.instanceof(VASTLoaderError)
@@ -349,10 +352,10 @@ describe('VASTLoader', function () {
   describe('fetch option', function () {
     it('overwrites fetch per instance', async function () {
       const loader1 = createLoader('tremor-video/vast_inline_linear.xml', {
-        fetch: (...args) => mockFetch(EMPTY_VAST_2)
+        fetch: mockFetch(EMPTY_VAST_2)
       })
       const loader2 = createLoader('tremor-video/vast_inline_linear.xml', {
-        fetch: (...args) => mockFetch(EMPTY_VAST_3)
+        fetch: mockFetch(EMPTY_VAST_3)
       })
       loader1.on('didFetch', ({ body }) => {
         expect(body).to.equal(EMPTY_VAST_2)

--- a/test/unit/node.js
+++ b/test/unit/node.js
@@ -8,6 +8,12 @@ const { atob } = require('../../lib/node/atob')
 
 VASTLoader.atob = atob
 
+const EMPTY_VAST_2 = `<?xml version="1.0" encoding="UTF-8"?><VAST version="2.0"/>`
+const EMPTY_VAST_3 = `<?xml version="1.0" encoding="UTF-8"?><VAST version="2.0"/>`
+
+const mockFetch = body =>
+  new Promise((resolve, reject) => resolve({ ok: true, text: () => body }))
+
 const expectLoaderError = (error, code, message, cause) => {
   expect(error).to.be.an.instanceof(VASTLoaderError)
   expect(error.code).to.equal(code)
@@ -337,6 +343,24 @@ describe('VASTLoader', function () {
       expect(localFetch.callCount).to.equal(2)
       expect(localFetch.firstCall.args[1]).to.eql({ credentials: 'include' })
       expect(localFetch.secondCall.args[1]).to.eql({ credentials: 'omit' })
+    })
+  })
+
+  describe('fetch option', function () {
+    it('overwrites fetch per instance', async function () {
+      const loader1 = createLoader('tremor-video/vast_inline_linear.xml', {
+        fetch: (...args) => mockFetch(EMPTY_VAST_2)
+      })
+      const loader2 = createLoader('tremor-video/vast_inline_linear.xml', {
+        fetch: (...args) => mockFetch(EMPTY_VAST_3)
+      })
+      loader1.on('didFetch', ({ body }) => {
+        expect(body).to.equal(EMPTY_VAST_3)
+      })
+      loader1.on('didFetch', ({ body }) => {
+        expect(body).to.equal(EMPTY_VAST_2)
+      })
+      await Promise.all([loader1.load(), loader2.load()])
     })
   })
 })


### PR DESCRIPTION
Added the option for a VASTLoader instance to override the `fetch` on an instance-basis instead of only on a `VASTLoader.fetch` basis. This allows for multiple loader instances to use different fetch strategies.

Goal is to be backwards compatible, so it falls back to `VASTLoader.fetch`.