### PR TITLE
Clone consecutive responses

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -109,18 +109,21 @@ class VASTLoader extends EventEmitter {
       credentials = [credentials]
     }
     return credentials.reduce(
-      (prev, cred) => prev.catch(() => this._tryFetch(uri, cred)),
+      (prev, cred, idx) => prev.catch(() => this._tryFetch(uri, cred, idx > 0)),
       Promise.reject(new Error())
     )
   }
 
-  _tryFetch (uri, credentials) {
+  _tryFetch (uri, credentials, cloneResponse) {
     return this._root
       ._fetch(uri, { credentials })
       .then(response => {
         if (!response.ok) {
           const httpError = new HTTPError(response.status, response.statusText)
           throw new VASTLoaderError(301, httpError, uri)
+        }
+        if (cloneResponse && typeof response.clone === 'function') {
+          response = response.clone()
         }
         return response.text().then(body => ({
           headers: response.headers,


### PR DESCRIPTION
When passing an array of `credentials` settings, it's possible that caching kicks in and we try to consume the same `Response` body twice, triggering a rejection.

According to [this Stack Overflow answer](https://stackoverflow.com/a/54115314), the solution is to `clone()` the `Response`, so this PR adds that for every consecutive fetch of the same URL.

However, according to the Fetch spec, [it actually won't help](https://fetch.spec.whatwg.org/#dom-response-clone):

> 1. If the context object is disturbed or locked, then throw a `TypeError`.

If we were able to reproduce the alleged caching problem, maybe that would tell us more.